### PR TITLE
Implementación de toda la configuración de los contenedores Docker en tiempo de invocación

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM maven:3.5-jdk-8-alpine
 VOLUME /tmp
-ARG JAR_FILE
-ADD ${JAR_FILE} /usr/share/agents_e3b/agents_e3b.jar
-EXPOSE 8091
-ENTRYPOINT ["/usr/bin/java","-jar","/usr/share/agents_e3b/agents_e3b.jar" \
+ADD "target/agents_e3b-0.0.1-SNAPSHOT.jar" "/maven/usr/share/agents_e3b/agents_e3b.jar"
+EXPOSE 8090
+ENTRYPOINT ["/usr/bin/java" \
 			,"-Djava.security.egd=file:/dev/./urandom" \
-			,"--spring.datasource.url=jdbc:postgresql://postgres:5432/postgres" \
+			,"-jar" \
+			,"/maven/usr/share/agents_e3b/agents_e3b.jar" \
 ]

--- a/docker-compose.management.yml
+++ b/docker-compose.management.yml
@@ -1,15 +1,19 @@
 version: '3.6'
 
-services:
+networks:
+  backend_network:
+    external:
+      name: backend_network
 
+services:
   pgadmin4:
     image: dpage/pgadmin4
-    ports:
-      - "80:5433"
     environment:
       PGADMIN_DEFAULT_EMAIL: container@pgadmin.org
-      PGADMIN_DEFAULT_PASSWORD: Conta1ner
+      PGADMIN_DEFAULT_PASSWORD: changeit
       PGADMIN_SERVER_NAME: pgadmin4
-    links:
-      - postgres
+    ports:
+      - "5433:80"
+    networks:
+      - backend_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/postgres
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: changeit
+      SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
+      SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
+      SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+      CSV_FILEPATHNAME: tipo_agentes.csv
     ports:
       - "8090:8090"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,35 @@
 version: '3.6'
 
-services:
+networks:
+  backend_network:
+    external:
+      name: backend_network
 
+services:
   postgres:
     image: postgres:alpine
-    ports:
-      - "5432:5432"
-    restart: always
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: changeit
+    ports:
+      - "5432:5432"
+    networks:
+      - backend_network
 
-  agents:
+  agents_e3b:
     build:
       context: .
-      args:
-        JAR_FILE: /target/agents_e3b-0.0.1-SNAPSHOT.jar
-    image: arquisoft/agents_e3b
+    image: arquisoft.ddns.net/agents_e3b
+    environment:
+      SERVER_PORT: 8090
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/postgres
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: changeit
     ports:
       - "8090:8090"
-    links:
+    networks:
+      - backend_network
+    volumes:
+      - /tmp
+    depends_on:
       - postgres

--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,15 @@
 		<agents.docker.alias>${project.artifactId}</agents.docker.alias>
 		<agents.docker.image>${docker.registry.address}/${agents.docker.alias}</agents.docker.image>
 		<agents.server.port>8090</agents.server.port>
+		<agents.cvs.filepathname>tipo_agentes.csv</agents.cvs.filepathname>
 
 		<server.port>${agents.server.port}</server.port>
-
 		<spring.datasource.url>jdbc:postgresql://${postgres.docker.alias}:${postgres.server.port}/${postgres.db}</spring.datasource.url>
 		<spring.datasource.username>${postgres.user}</spring.datasource.username>
 		<spring.datasource.password>${postgres.password}</spring.datasource.password>
 		<spring.datasource.driverClassName>org.postgresql.Driver</spring.datasource.driverClassName>
 		<spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>
-
-		<csv.filepathname>tipo_agentes.csv</csv.filepathname>
+		<csv.filepathname>${agents.cvs.filepathname}</csv.filepathname>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,28 @@
 
 		<docker.registry.address>arquisoft.ddns.net</docker.registry.address>
 		<docker.base.image>maven:3.5-jdk-8-alpine</docker.base.image>
-		<docker.backend.network.name>backend</docker.backend.network.name>
+		<docker.backend.network.name>backend_network</docker.backend.network.name>
+
 		<postgres.docker.alias>postgres</postgres.docker.alias>
+		<postgres.docker.image>${postgres.docker.alias}:alpine</postgres.docker.image>
 		<postgres.server.port>5432</postgres.server.port>
 		<postgres.user>postgres</postgres.user>
 		<postgres.password>changeit</postgres.password>
-		<spring.datasource.url>jdbc:postgresql://${postgres.docker.alias}:${postgres.server.port}/postgres</spring.datasource.url>
+		<postgres.db>${postgres.user}</postgres.db>
+
 		<agents.docker.alias>${project.artifactId}</agents.docker.alias>
+		<agents.docker.image>${docker.registry.address}/${agents.docker.alias}</agents.docker.image>
 		<agents.server.port>8090</agents.server.port>
+
+		<server.port>${agents.server.port}</server.port>
+
+		<spring.datasource.url>jdbc:postgresql://${postgres.docker.alias}:${postgres.server.port}/${postgres.db}</spring.datasource.url>
+		<spring.datasource.username>${postgres.user}</spring.datasource.username>
+		<spring.datasource.password>${postgres.password}</spring.datasource.password>
+		<spring.datasource.driverClassName>org.postgresql.Driver</spring.datasource.driverClassName>
+		<spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>
+
+		<csv.filepathname>tipo_agentes.csv</csv.filepathname>
 	</properties>
 
 	<dependencies>
@@ -139,11 +153,12 @@
 					<images>
 						<image>
 							<alias>${postgres.docker.alias}</alias>
-							<name>${postgres.docker.alias}:alpine</name>
+							<name>${postgres.docker.image}</name>
 							<run>
 								<env>
 									<POSTGRES_USER>${postgres.user}</POSTGRES_USER>
 									<POSTGRES_PASSWORD>${postgres.password}</POSTGRES_PASSWORD>
+									<POSTGRES_DB>${postgres.db}</POSTGRES_DB>
 								</env>
 								<ports>
 									<port>${postgres.server.port}:${postgres.server.port}</port>
@@ -166,7 +181,7 @@
 						</image>
 						<image>
 							<alias>${agents.docker.alias}</alias>
-							<name>${docker.registry.address}/${agents.docker.alias}</name>
+							<name>${agents.docker.image}</name>
 							<build>
 								<from>${docker.base.image}</from>
 								<tags>
@@ -194,17 +209,18 @@
 									<arg>-Djava.security.egd=file:/dev/./urandom</arg>
 									<arg>-jar</arg>
 									<arg>/maven/usr/share/${project.artifactId}/${project.artifactId}-${project.version}.${project.packaging}</arg>
-									<arg>--spring.datasource.url=${spring.datasource.url}</arg>
-									<arg>--spring.datasource.username=${postgres.user}</arg>
-									<arg>--spring.datasource.password=${postgres.password}</arg>
 								</entryPoint>
 							</build>
 							<run>
-								<volumes>
-									<bind>
-										<volume>/tmp</volume>
-									</bind>
-								</volumes>
+								<env>
+									<SERVER_PORT>${server.port}</SERVER_PORT>
+									<SPRING_DATASOURCE_URL>${spring.datasource.url}</SPRING_DATASOURCE_URL>
+									<SPRING_DATASOURCE_USERNAME>${spring.datasource.username}</SPRING_DATASOURCE_USERNAME>
+									<SPRING_DATASOURCE.PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE.PASSWORD>
+									<SPRING_DATASOURCE_DRIVERCLASSNAME>${spring.datasource.driverClassName}</SPRING_DATASOURCE_DRIVERCLASSNAME>
+									<SPRING_JPA_HIBERNATE_DDL-AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL-AUTO>
+									<CSV_FILEPATHNAME>${csv.filepathname}</CSV_FILEPATHNAME>
+								</env>
 								<ports>
 									<port>${agents.server.port}:${agents.server.port}</port>
 								</ports>
@@ -213,6 +229,11 @@
 									<name>${docker.backend.network.name}</name>
 									<alias>${agents.docker.alias}</alias>
 								</network>
+								<volumes>
+									<bind>
+										<volume>/tmp</volume>
+									</bind>
+								</volumes>
 								<dependsOn>
 									<container>${postgres.docker.alias}</container>
 								</dependsOn>
@@ -359,6 +380,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>${maven-project-info-reports-plugin.version}</version>
 				<configuration>
 					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
 					<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
@@ -382,12 +404,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>${maven-pmd-plugin}</version>
+				<version>${maven-pmd-plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>${cobertura-maven-plugin}</version>
+				<version>${cobertura-maven-plugin.version}</version>
 				<configuration>
 					<formats>
 						<format>html</format>

--- a/pom.xml
+++ b/pom.xml
@@ -216,10 +216,10 @@
 									<SERVER_PORT>${server.port}</SERVER_PORT>
 									<SPRING_DATASOURCE_URL>${spring.datasource.url}</SPRING_DATASOURCE_URL>
 									<SPRING_DATASOURCE_USERNAME>${spring.datasource.username}</SPRING_DATASOURCE_USERNAME>
-									<SPRING_DATASOURCE.PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE.PASSWORD>
+									<SPRING_DATASOURCE_PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE_PASSWORD>
 									<SPRING_DATASOURCE_DRIVERCLASSNAME>${spring.datasource.driverClassName}</SPRING_DATASOURCE_DRIVERCLASSNAME>
 									<SPRING_JPA_DATABASE_PLATFORM>${spring.jpa.database-platform}</SPRING_JPA_DATABASE_PLATFORM>
-									<SPRING_JPA_HIBERNATE_DDL-AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL-AUTO>
+									<SPRING_JPA_HIBERNATE_DDL_AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL_AUTO>
 									<CSV_FILEPATHNAME>${csv.filepathname}</CSV_FILEPATHNAME>
 								</env>
 								<ports>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 		<spring.datasource.username>${postgres.user}</spring.datasource.username>
 		<spring.datasource.password>${postgres.password}</spring.datasource.password>
 		<spring.datasource.driverClassName>org.postgresql.Driver</spring.datasource.driverClassName>
+		<spring.jpa.database-platform>org.hibernate.dialect.PostgreSQLDialect</spring.jpa.database-platform>
 		<spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>
 		<csv.filepathname>${agents.cvs.filepathname}</csv.filepathname>
 	</properties>
@@ -217,6 +218,7 @@
 									<SPRING_DATASOURCE_USERNAME>${spring.datasource.username}</SPRING_DATASOURCE_USERNAME>
 									<SPRING_DATASOURCE.PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE.PASSWORD>
 									<SPRING_DATASOURCE_DRIVERCLASSNAME>${spring.datasource.driverClassName}</SPRING_DATASOURCE_DRIVERCLASSNAME>
+									<SPRING_JPA_DATABASE_PLATFORM>${spring.jpa.database-platform}</SPRING_JPA_DATABASE_PLATFORM>
 									<SPRING_JPA_HIBERNATE_DDL-AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL-AUTO>
 									<CSV_FILEPATHNAME>${csv.filepathname}</CSV_FILEPATHNAME>
 								</env>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.datasource.url = jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=changeit
 spring.datasource.driverClassName=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=create-drop
 
 csv.filepathname = tipo_agentes.csv

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,9 @@
-#server.address = localhost
 server.port = 8090
-csv.filepathname = tipo_agentes.csv
+
 spring.datasource.url = jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=changeit
-spring.jpa.hibernate.ddl-auto=create-drop
 spring.datasource.driverClassName=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+
+csv.filepathname = tipo_agentes.csv


### PR DESCRIPTION
Incluye toda la configuración de los contendedores como properties dentro del fichero POM, permitiendo transmitírsela en forma de variables de entorno durante el proceso de invocación (sobreescribiendo el contenido del fichero application.properties).

Ver también: Issue #23, Arquisoft/Inci_e3b_modules#5